### PR TITLE
Adjusting getElement function

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -52,16 +52,12 @@
 		}
 		var elem = !parent ? document.body : parent;
 		var elementArr = elementConfig[id];
-		for (var x in elementArr){
-			var pos = elementArr[x];
-			if (isNaN(pos*1)){ //dont know why, but for some reason after the last position it loops once again and "pos" is loaded with a function WTF. I got tired finding why and did this
-				continue;
-			}
+		elementArr.forEach(function(pos) {
 			if (!elem.childNodes[pos]){
 				return false;
 			}
 			elem = elem.childNodes[pos];
-		}
+		});
 		return elem;
 	}
 	


### PR DESCRIPTION
I think that the syntax "for (var x in array)" loops the properties of objects, so if you do something like "Array.prototype.remove = ..." "remove" becomes a property of object. I console.log the "x" var and the last property is just "remove" that is not documented in Javascript docs...probably it was added in run time.
I switched the for-in syntax to [].forEach